### PR TITLE
距離の変数名を変更

### DIFF
--- a/src/data/gpx.ts
+++ b/src/data/gpx.ts
@@ -18,7 +18,7 @@ export function parseGpx(input: string): RouteData | undefined {
     name: '',
     coordinates: [],
     color: '',
-    totalDistance: 0,
+    distance: 0,
     gainedAltitude: null,
   };
 
@@ -27,7 +27,7 @@ export function parseGpx(input: string): RouteData | undefined {
   const track = gpx.tracks[0];
 
   data.coordinates = track.points.map((p) => ({ longitude: p.longitude, latitude: p.latitude }));
-  data.totalDistance = track.distance.total;
+  data.distance = track.distance.total;
   data.gainedAltitude = track.elevation.positive;
 
   return data;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -33,7 +33,7 @@ export type RouteData = {
   /**
    * 総距離
    */
-  totalDistance: number;
+  distance: number;
   /**
    * 累計獲得標高
    */


### PR DESCRIPTION
## 概要

GPX データの情報を表す `RouteData` 型の中で、距離を表す変数名を変更する。

`gpxjs` の GPX ファイルのパース結果から得られる、トラックの距離は2種類ある。

- `total: number`: 総距離
- `cumulative: number[]`: 各ポイントまでの累積距離

これまでは `track.distance.total` の値を採用していたためにそのまま `totalDistance` という変数名にしていたが、実情としては単に `distance` とする方が正確であるため、変更する。
