### PR TITLE
chore: アプリ名とバージョンを編集

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gpx-viewer",
+  "name": "kiseki",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
アプリ名がプロジェクト作成時の古いままとなっていたため、現在の名前に合わせて修正する。

バージョンが設定されていなかったため、設定する。
