### PR TITLE
水面のスタイルを変更

### DIFF
--- a/src/mapStyles/osm-bright-ja-white.json
+++ b/src/mapStyles/osm-bright-ja-white.json
@@ -1804,7 +1804,7 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "filter": ["all", ["in", "admin_level", 2, 4], ["==", "maritime", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "none" },
       "paint": {
         "line-color": "rgb(184,184,184)",
         "line-opacity": {

--- a/src/mapStyles/osm-bright-ja-white.json
+++ b/src/mapStyles/osm-bright-ja-white.json
@@ -364,7 +364,7 @@
       "source": "openmaptiles",
       "source-layer": "water",
       "filter": ["all"],
-      "layout": { "visibility": "visible" },
+      "layout": { "visibility": "none" },
       "paint": { "fill-pattern": "wave", "fill-translate": [0, 2.5] }
     },
     {


### PR DESCRIPTION
水面のスタイルが見にくかったため、以下の点を変更する。

- 水面の波線を非表示化。
- 水面の境界線を非表示化。

Before | After
-|-
![image](https://github.com/user-attachments/assets/7c8fa8b7-1c95-49f2-9f1d-4beae7b06bd2)|![image](https://github.com/user-attachments/assets/0e15528e-b90c-4fce-a0e9-6d47bf48c983)


