### PR TITLE
ズームレベルに応じた間引き機能を追加

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -13,6 +13,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { Point, RouteData } from '../data/types';
 import { useAppState } from '../data/stores';
 import styleWhite from '../mapStyles/osm-bright-ja-white.json';
+import { thresholdFromZoom } from '../data/utils';
 
 function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl(() => new DeckOverlay(props));
@@ -94,7 +95,7 @@ function createPathLayer(sourceData: RouteData[], zoom: number) {
  * ズームレベルを参照し、適度に間引いた座標を返す
  */
 function reduceCoordinates(points: Point[], zoom: number): [number, number][] {
-  const threshold = 50 / zoom; // ズームレベルから計算した間隔のしきい値[m]
+  const threshold = thresholdFromZoom(zoom); // ズームレベルから計算した間隔のしきい値[m]
   let dist = 0; // 前回からの累積の間隔[m]
 
   const array: [number, number][] = [];
@@ -119,6 +120,8 @@ function reduceCoordinates(points: Point[], zoom: number): [number, number][] {
   ) {
     array.push([points[points.length - 1].longitude, points[points.length - 1].latitude]);
   }
+
+  // console.log(zoom, threshold, array.length);
 
   return array;
 }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -10,7 +10,7 @@ import {
 import { PathLayer } from 'deck.gl';
 import { MapboxOverlay as DeckOverlay, MapboxOverlayProps } from '@deck.gl/mapbox';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { RouteData } from '../data/types';
+import { Point, RouteData } from '../data/types';
 import { useAppState } from '../data/stores';
 import styleWhite from '../mapStyles/osm-bright-ja-white.json';
 
@@ -24,15 +24,12 @@ function DeckGLOverlay(props: MapboxOverlayProps) {
  * 地図を表示するビュー
  */
 export function MapView() {
+  const [zoom, setZoom] = React.useState(7);
   const [initialViewState] = React.useState({
     longitude: 137.48,
     latitude: 36,
-    zoom: 7,
+    zoom,
   });
-
-  const dataList = useAppState((state) => state.dataList);
-  const pathLayer = React.useMemo(() => createPathLayer(dataList), [dataList]);
-  const layers = React.useMemo(() => [pathLayer], [pathLayer]);
 
   // TODO: パスがセットされたら表示領域をパスにフィットさせる
   // https://deck.gl/docs/api-reference/core/web-mercator-viewport#fitbounds
@@ -43,22 +40,107 @@ export function MapView() {
       style={{ width: '100dvw', height: '100dvh' }}
       initialViewState={initialViewState}
       mapStyle={styleWhite as MapStyle}
+      onZoomEnd={(e) => setZoom(e.viewState.zoom)}
     >
       <NavigationControl position="top-right" />
       <GeolocateControl />
       <ScaleControl />
-      <DeckGLOverlay layers={layers} />
+      <LineOverlay zoom={zoom} />
     </Map>
   );
 }
 
-function createPathLayer(data: RouteData[]) {
-  return new PathLayer<RouteData>({
+/**
+ * 線を描画するオーバーレイレイヤー
+ */
+function LineOverlay({ zoom }: { zoom: number }) {
+  const dataList = useAppState((state) => state.dataList);
+  const pathLayer = createPathLayer(dataList, zoom);
+  const layers = React.useMemo(() => [pathLayer], [pathLayer]);
+
+  return <DeckGLOverlay layers={layers} />;
+}
+
+/**
+ * 描画する線のレイヤーを生成する
+ *
+ * ズームレベルを元に間引く
+ */
+function createPathLayer(sourceData: RouteData[], zoom: number) {
+  type LocalData = {
+    coordinates: [number, number][];
+    color: [number, number, number];
+  };
+  const data: LocalData[] = sourceData.map(
+    (d) =>
+      ({
+        color: d.color,
+        coordinates: reduceCoordinates(d.coordinates, zoom),
+      } satisfies LocalData)
+  );
+
+  return new PathLayer<LocalData>({
     id: `PathLayer`,
-    data: data,
-    getPath: (d) => d.coordinates.map((v) => [v.longitude, v.latitude] as [number, number]),
+    data,
+    getPath: (d) => d.coordinates,
     getWidth: () => 2,
     getColor: (d) => d.color,
     widthUnits: 'pixels',
+    jointRounded: true,
   });
+}
+
+/**
+ * ズームレベルを参照し、適度に間引いた座標を返す
+ */
+function reduceCoordinates(points: Point[], zoom: number): [number, number][] {
+  const threshold = 50 / zoom; // ズームレベルから計算した間隔のしきい値[m]
+  let dist = 0; // 前回からの累積の間隔[m]
+
+  const array: [number, number][] = [];
+
+  // 最初の地点は必ず登録
+  array.push([points[0].longitude, points[0].latitude]);
+
+  for (let i = 0; i < points.length - 1; i++) {
+    const prev = points[0];
+    const now = points[1];
+    dist += distance(prev.longitude, prev.latitude, now.longitude, now.latitude);
+    if (threshold <= dist) {
+      array.push([points[i + 1].longitude, points[i + 1].latitude]);
+      dist = 0;
+    }
+  }
+
+  // 最後の地点が最後の座標と異なる場合は追加
+  if (
+    points[points.length - 1].longitude !== array[array.length - 1][0] &&
+    points[points.length - 1].latitude !== array[array.length - 1][1]
+  ) {
+    array.push([points[points.length - 1].longitude, points[points.length - 1].latitude]);
+  }
+
+  return array;
+}
+
+/**
+ * 2点間の距離[m] を算出する
+ */
+function distance(
+  longitude1: number,
+  latitude1: number,
+  longitude2: number,
+  latitude2: number
+): number {
+  const R = Math.PI / 180;
+  const lng1 = longitude1 * R;
+  const lat1 = latitude1 * R;
+  const lng2 = longitude2 * R;
+  const lat2 = latitude2 * R;
+  return (
+    6371000 *
+    Math.acos(
+      Math.cos(lat1) * Math.cos(lat2) * Math.cos(lng2 - lng1) + Math.sin(lat1) * Math.sin(lat2)
+    )
+  );
 }

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -21,3 +21,34 @@ export function numbersFromHex(hex: string): [number, number, number] {
   const b = parseInt(hex.slice(5, 7), 16);
   return [r, g, b];
 }
+
+/**
+ * 地図のズームレベルから、間引くためのしきい値[m] を計算する。
+ */
+export function thresholdFromZoom(zoom: number): number {
+  if (zoom < 1) {
+    return 10000;
+  } else if (zoom < 3) {
+    return 5000;
+  } else if (zoom < 4) {
+    return 1000;
+  } else if (zoom < 5) {
+    return 500;
+  } else if (zoom < 6) {
+    return 200;
+  } else if (zoom < 7) {
+    return 150;
+  } else if (zoom < 8) {
+    return 100;
+  } else if (zoom < 9) {
+    return 80;
+  } else if (zoom < 10) {
+    return 60;
+  } else if (zoom < 12) {
+    return 40;
+  } else if (zoom < 14) {
+    return 20;
+  }
+
+  return 10;
+}


### PR DESCRIPTION
## 概要

地図のズームレベルに応じて座標を間引き、表示を軽量化する処理を追加する。

### 実装の詳細メモ

ズームレベルを `useMap()` で取得しようとしたが、変更時の値を取得できない。したがって `useState()` で保持し、変更時にこの値を `set` する実装としている。

`new PathLayer` の `getPath()` がズームレベルに応じて間引いた座標を返すだけでは、表示に反映されない。そのため、データ自体を間引く実装としている。

## モチベーション

これまでは GPX ファイルのすべての座標を描画していたが、ズームレベルを下げてズームアウトした際には極端に描画パフォーマンスが低下していた。その改善として描画する座標自体を減らす対策を行う。

## 今後の課題

### パフォーマンス

ただしこの対策後でも描画パフォーマンス自体はそれほど良くない。特に大量の座標を持つ大量の GPX　ファイルを開いたときが顕著。

恐らく、ズームレベルを変えるたびに座標の間引きとレイヤーの生成を行っているためと推測される。

これを解決するために、ズームレベル（段階）ごとの線のレイヤーを保持しておく対策がありうる。

### 間引き間隔の算出

間引き間隔は `if` 文で列挙しているが、以下の数式でも良い感じに算出できる。

```ts
return 100000 * Math.pow(0.1, zoom / 3);
```

今後の実装次第ではあるが、この式に書き換えても良い。
